### PR TITLE
perf(LastFM): only use `get_recent_tracks`

### DIFF
--- a/music/lastfm.py
+++ b/music/lastfm.py
@@ -64,15 +64,9 @@ async def lastfm_status(
         return
 
     user = lastfm.get_user(USERNAME)
-    now_playing = user.get_now_playing()
-
-    if now_playing:
-        recent_tracks = [pylast.PlayedTrack(now_playing, None, None, None)]
-        if expanded:
-            recent_tracks += user.get_recent_tracks(limit=3)
-    else:
-        limit = 4 if expanded else 1
-        recent_tracks = user.get_recent_tracks(limit=limit)
+    recent_tracks = user.get_recent_tracks(
+        limit=4 if expanded else 1, now_playing=True
+    )
     text = "{} {} listening to".format(
         user.name, "was" if recent_tracks[0].timestamp else "is now"
     )


### PR DESCRIPTION
Reverts commits:
- e0ec687: fix(LastFM): handle if `get_now_playing` is None
- 11835fb: refactor(LastFM): [TMP] use `get_now_playing` alongside `get_recent_tracks`

Also reformats code via `black`.